### PR TITLE
fix(chat): chain errors in chat

### DIFF
--- a/aigc-director/aigc-claw/backend/tool/vlm_dashscope.py
+++ b/aigc-director/aigc-claw/backend/tool/vlm_dashscope.py
@@ -58,7 +58,7 @@ class QwenVLClient:
             else:
                 raise RuntimeError(f"DashScope QwenVLClient failed: {getattr(response, 'message', response)}")
         except Exception as e:
-            raise RuntimeError(f"DashScope QwenVLClient error: {e}")
+            raise RuntimeError(f"DashScope QwenVLClient error: {e}") from e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Spotted something in aigc-director/aigc-claw/backend/tool/vlm_dashscope.py that might be worth a look: The wrapper exception drops the original cause. this patch chains it with from so the real failure still shows up in tracebacks — happy to close if this isn’t useful.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.