### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/video-claw/video-claw/backend/config.py
+++ b/video-claw/video-claw/backend/config.py
@@ -40,6 +40,11 @@ DEFAULT_CONFIG: Dict[str, Any] = {
             "base_url": "https://api.deepseek.com/v1",
             "enable_proxy": False,
         },
+        "atlascloud": {
+            "api_key": "",
+            "base_url": "https://api.atlascloud.ai/v1",
+            "enable_proxy": False,
+        },
         "dashscope": {
             "api_key": "",
             "base_url": "https://dashscope.aliyuncs.com/api/v1",
@@ -220,6 +225,19 @@ class Config:
     DEEPSEEK_API_KEY = _get(CONFIG, "api_providers.deepseek.api_key")
     DEEPSEEK_BASE_URL = _get(CONFIG, "api_providers.deepseek.base_url")
     DEEPSEEK_ENABLE_PROXY = _get(CONFIG, "api_providers.deepseek.enable_proxy")
+    ATLASCLOUD_API_KEY = (
+        _get(CONFIG, "api_providers.atlascloud.api_key")
+        or os.getenv("ATLASCLOUD_API_KEY")
+        or os.getenv("ATLAS_CLOUD_API_KEY")
+        or ""
+    )
+    ATLASCLOUD_BASE_URL = (
+        _get(CONFIG, "api_providers.atlascloud.base_url")
+        or os.getenv("ATLASCLOUD_API_BASE")
+        or os.getenv("ATLAS_CLOUD_API_BASE")
+        or "https://api.atlascloud.ai/v1"
+    )
+    ATLASCLOUD_ENABLE_PROXY = _get(CONFIG, "api_providers.atlascloud.enable_proxy")
     DASHSCOPE_API_KEY = _get(CONFIG, "api_providers.dashscope.api_key")
     DASHSCOPE_BASE_URL = _get(CONFIG, "api_providers.dashscope.base_url")
     DASHSCOPE_ENABLE_PROXY = _get(CONFIG, "api_providers.dashscope.enable_proxy")
@@ -294,6 +312,19 @@ class Config:
         cls.DEEPSEEK_API_KEY = _get(clean, "api_providers.deepseek.api_key")
         cls.DEEPSEEK_BASE_URL = _get(clean, "api_providers.deepseek.base_url")
         cls.DEEPSEEK_ENABLE_PROXY = _get(clean, "api_providers.deepseek.enable_proxy")
+        cls.ATLASCLOUD_API_KEY = (
+            _get(clean, "api_providers.atlascloud.api_key")
+            or os.getenv("ATLASCLOUD_API_KEY")
+            or os.getenv("ATLAS_CLOUD_API_KEY")
+            or ""
+        )
+        cls.ATLASCLOUD_BASE_URL = (
+            _get(clean, "api_providers.atlascloud.base_url")
+            or os.getenv("ATLASCLOUD_API_BASE")
+            or os.getenv("ATLAS_CLOUD_API_BASE")
+            or "https://api.atlascloud.ai/v1"
+        )
+        cls.ATLASCLOUD_ENABLE_PROXY = _get(clean, "api_providers.atlascloud.enable_proxy")
         cls.DASHSCOPE_API_KEY = _get(clean, "api_providers.dashscope.api_key")
         cls.DASHSCOPE_BASE_URL = _get(clean, "api_providers.dashscope.base_url")
         cls.DASHSCOPE_ENABLE_PROXY = _get(clean, "api_providers.dashscope.enable_proxy")

--- a/video-claw/video-claw/backend/config.yaml.example
+++ b/video-claw/video-claw/backend/config.yaml.example
@@ -20,6 +20,10 @@ api_providers:
     api_key: ''
     base_url: https://api.deepseek.com/v1
     enable_proxy: false
+  atlascloud:
+    api_key: ''
+    base_url: https://api.atlascloud.ai/v1
+    enable_proxy: false
   dashscope:
     api_key: ''
     base_url: https://dashscope.aliyuncs.com/api/v1

--- a/video-claw/video-claw/backend/models/config_model.py
+++ b/video-claw/video-claw/backend/models/config_model.py
@@ -12,8 +12,8 @@ backend_dir = os.path.dirname(models_dir)
 if backend_dir not in sys.path:
     sys.path.insert(0, backend_dir)
 
-from copy import deepcopy
-from typing import Any, Optional
+from copy import deepcopy  # noqa: E402
+from typing import Any, Optional  # noqa: E402
 
 MODEL_CONFIG: dict[str, Any] = {'models': {'deepseek-chat': {'name': 'DeepSeek Chat',
                               'provider': 'deepseek',
@@ -39,6 +39,18 @@ MODEL_CONFIG: dict[str, Any] = {'models': {'deepseek-chat': {'name': 'DeepSeek C
                                 'concurrency': 10,
                                 'price_per_1k_input_token': 0.002,
                                 'price_per_1k_output_token': 0.008},
+            'qwen/qwen3.5-flash': {'name': 'Qwen 3.5 Flash (Atlas Cloud)',
+                                   'provider': 'atlascloud',
+                                   'family': 'qwen',
+                                   'type': ['llm'],
+                                   'concurrency': 10,
+                                   'api_contract_verified': True},
+            'deepseek-ai/deepseek-v4-pro': {'name': 'DeepSeek V4 Pro (Atlas Cloud)',
+                                            'provider': 'atlascloud',
+                                            'family': 'deepseek',
+                                            'type': ['llm'],
+                                            'concurrency': 10,
+                                            'api_contract_verified': True},
             'gpt-4o': {'name': 'GPT-4o',
                        'provider': 'openai',
                        'type': ['llm'],

--- a/video-claw/video-claw/backend/models/llm_atlascloud.py
+++ b/video-claw/video-claw/backend/models/llm_atlascloud.py
@@ -1,0 +1,37 @@
+"""Atlas Cloud OpenAI-compatible LLM client."""
+
+import os
+import sys
+
+models_dir = os.path.dirname(os.path.abspath(__file__))
+backend_dir = os.path.dirname(models_dir)
+if backend_dir not in sys.path:
+    sys.path.insert(0, backend_dir)
+
+from config import Config  # noqa: E402
+from models.llm_gpt import GPT  # noqa: E402
+
+
+class AtlasCloud(GPT):
+    """Atlas Cloud text generation client using the OpenAI-compatible chat API."""
+
+    def __init__(self, base_url: str = "", api_key: str = "", timeout: int = 300):
+        super().__init__(
+            base_url=base_url or Config.ATLASCLOUD_BASE_URL,
+            api_key=api_key or Config.ATLASCLOUD_API_KEY,
+            proxy=Config.provider_proxy("atlascloud"),
+            timeout=timeout,
+        )
+
+    def query(self, prompt, image_urls=None, model="qwen/qwen3.5-flash", web_search=False):
+        if image_urls:
+            raise ValueError("Atlas Cloud LLM models registered here are text-only.")
+        if web_search:
+            raise ValueError("Atlas Cloud provider does not support Video-Claw web_search mode.")
+        model = model or "qwen/qwen3.5-flash"
+        model_lower = model.lower()
+        for prefix in ("atlascloud/", "atlas-cloud/", "atlas/"):
+            if model_lower.startswith(prefix):
+                model = model[len(prefix):]
+                break
+        return super().query(prompt, image_urls=[], model=model or "qwen/qwen3.5-flash")

--- a/video-claw/video-claw/backend/models/llm_client.py
+++ b/video-claw/video-claw/backend/models/llm_client.py
@@ -6,27 +6,42 @@ backend_dir = os.path.dirname(models_dir)
 if backend_dir not in sys.path:
     sys.path.insert(0, backend_dir)
 
-import logging
+import logging  # noqa: E402
 
 try:
-    from models.llm_gpt import GPT
-    from models.llm_gemini import Gemini
-    from models.llm_deepseek import DeepSeek
+    from models.config_model import get_model_config
+    from models.llm_atlascloud import AtlasCloud
     from models.llm_dashscope import QwenLLM
+    from models.llm_deepseek import DeepSeek
+    from models.llm_gemini import Gemini
+    from models.llm_gpt import GPT
     from models.vlm_dashscope import QwenVLClient
 except ImportError:
-    from llm_gpt import GPT
-    from llm_gemini import Gemini
-    from llm_deepseek import DeepSeek
+    from config_model import get_model_config
+    from llm_atlascloud import AtlasCloud
     from llm_dashscope import QwenLLM
+    from llm_deepseek import DeepSeek
+    from llm_gemini import Gemini
+    from llm_gpt import GPT
     from vlm_dashscope import QwenVLClient
 
-from config import Config
+from config import Config  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
 class LLM:
-    def __init__(self, gemini_base_url="", gemini_api_key="", gpt_base_url="", gpt_api_key="", deepseek_base_url="", deepseek_api_key="", dashscope_api_key=""):
+    def __init__(
+        self,
+        gemini_base_url="",
+        gemini_api_key="",
+        gpt_base_url="",
+        gpt_api_key="",
+        deepseek_base_url="",
+        deepseek_api_key="",
+        dashscope_api_key="",
+        atlascloud_base_url="",
+        atlascloud_api_key="",
+    ):
         self._gemini_base_url = gemini_base_url or Config.GOOGLE_GEMINI_BASE_URL
         self._gemini_api_key = gemini_api_key or Config.GEMINI_API_KEY
         self._gpt_base_url = gpt_base_url or Config.OPENAI_BASE_URL
@@ -34,12 +49,15 @@ class LLM:
         self._deepseek_base_url = deepseek_base_url or Config.DEEPSEEK_BASE_URL
         self._deepseek_api_key = deepseek_api_key or Config.DEEPSEEK_API_KEY
         self._dashscope_api_key = dashscope_api_key or Config.DASHSCOPE_API_KEY
+        self._atlascloud_base_url = atlascloud_base_url or Config.ATLASCLOUD_BASE_URL
+        self._atlascloud_api_key = atlascloud_api_key or Config.ATLASCLOUD_API_KEY
 
         self._gemini_client = None
         self._gpt_client = None
         self._deepseek_client = None
         self._dashscope_client = None
         self._dashscope_vl_client = None
+        self._atlascloud_client = None
 
     @property
     def gemini_client(self):
@@ -80,6 +98,15 @@ class LLM:
         if self._dashscope_vl_client is None:
             self._dashscope_vl_client = QwenVLClient(api_key=self._dashscope_api_key)
         return self._dashscope_vl_client
+
+    @property
+    def atlascloud_client(self):
+        if self._atlascloud_client is None:
+            self._atlascloud_client = AtlasCloud(
+                base_url=self._atlascloud_base_url,
+                api_key=self._atlascloud_api_key,
+            )
+        return self._atlascloud_client
 
     def full_to_half(self, text):
         if not isinstance(text, str):
@@ -123,7 +150,10 @@ class LLM:
             
         result = ""
         model_lower = model.lower()
-        if model_lower.startswith("gemini"):
+        provider = get_model_config(model).get("provider", "")
+        if provider == "atlascloud" or model_lower.startswith(("atlascloud/", "atlas-cloud/", "atlas/")):
+            result = self.atlascloud_client.query(prompt, image_urls=image_urls, model=model, web_search=web_search)
+        elif model_lower.startswith("gemini"):
             result = self.gemini_client.query(prompt, image_urls=image_urls, model=model)
         elif "gpt" in model_lower:
             # OpenAI series models

--- a/video-claw/video-claw/backend/tests/test_atlascloud_provider.py
+++ b/video-claw/video-claw/backend/tests/test_atlascloud_provider.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+
+def test_atlascloud_models_are_registered_as_llm():
+    from models.config_model import get_model_config, get_models_by_type, model_type_capabilities
+
+    llm_ids = {model["id"] for model in get_models_by_type("llm")}
+    assert "qwen/qwen3.5-flash" in llm_ids
+    assert "deepseek-ai/deepseek-v4-pro" in llm_ids
+
+    qwen = get_model_config("qwen/qwen3.5-flash")
+    assert qwen["provider"] == "atlascloud"
+    assert qwen["family"] == "qwen"
+    assert model_type_capabilities("llm", qwen)["api_contract_verified"] is True
+
+
+def test_atlascloud_config_defaults_and_environment_fallback(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-test-key")
+
+    import config as config_module
+
+    config_module = importlib.reload(config_module)
+    Config = config_module.Config
+
+    assert Config.ATLASCLOUD_API_KEY == "atlas-test-key"
+    assert Config.ATLASCLOUD_BASE_URL == "https://api.atlascloud.ai/v1"
+    assert Config.provider_proxy("atlascloud") == ""
+
+
+def test_llm_routes_registered_atlascloud_model(monkeypatch):
+    fake_openai = types.ModuleType("openai")
+    fake_openai.OpenAI = object
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+    fake_dashscope = types.ModuleType("dashscope")
+    fake_dashscope.Generation = object
+    fake_dashscope.MultiModalConversation = object
+    monkeypatch.setitem(sys.modules, "dashscope", fake_dashscope)
+
+    from models.llm_client import LLM
+
+    class FakeAtlasCloud:
+        def query(self, prompt, image_urls=None, model="", web_search=False):
+            return f"{model}:{prompt}:{bool(image_urls)}:{web_search}"
+
+    client = LLM(atlascloud_api_key="atlas-test-key")
+    monkeypatch.setattr(client, "_atlascloud_client", FakeAtlasCloud())
+
+    assert client.query("hello", model="qwen/qwen3.5-flash") == (
+        "qwen/qwen3.5-flash:hello:False:False"
+    )

--- a/video-claw/video-claw/frontend/lib/modelRegistry.ts
+++ b/video-claw/video-claw/frontend/lib/modelRegistry.ts
@@ -4,6 +4,7 @@ import { fetchApiModels } from '@/lib/workflowApi';
 const PROVIDER_LABELS: Record<string, string> = {
   dashscope: 'DashScope',
   ark: 'ARK (Volcengine)',
+  atlascloud: 'Atlas Cloud',
   deepseek: 'DeepSeek',
   openai: 'OpenAI',
   gemini: 'Gemini',


### PR DESCRIPTION
## Summary
- add an Atlas Cloud OpenAI-compatible LLM client and route registered Atlas models through it
- register qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro in the backend model catalog
- add atlascloud provider configuration, frontend provider label, and focused provider tests

## Validation
- python3 -m pytest video-claw/video-claw/backend/tests/test_atlascloud_provider.py
- env PYTHONPYCACHEPREFIX=/tmp/pycache-atlas-videoclaw python3 -m compileall -q video-claw/video-claw/backend/models video-claw/video-claw/backend/tests/test_atlascloud_provider.py
- env UV_CACHE_DIR=/tmp/uv-cache-atlas-videoclaw uv run --directory video-claw/video-claw/backend --locked --extra dev ruff check models/llm_atlascloud.py models/llm_client.py models/config_model.py config.py tests/test_atlascloud_provider.py
- npx tsc --noEmit --pretty false in video-claw/video-claw/frontend
- git diff --check
- Atlas Cloud live model catalog returned 374 visible models and confirmed qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

Note: npm run lint currently fails before checking files because the existing ESLint flat config loads an extends key; the targeted frontend TypeScript typecheck passes.

No README changes; no sponsor, logo, credits, or partner promotion added.